### PR TITLE
Do not setting aritwork uri for MediaItem

### DIFF
--- a/core/data/src/androidMain/kotlin/com/andannn/melodify/core/data/repository/MediaItemMapper.kt
+++ b/core/data/src/androidMain/kotlin/com/andannn/melodify/core/data/repository/MediaItemMapper.kt
@@ -6,6 +6,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import com.andannn.melodify.core.data.model.AudioItemModel
 import com.andannn.melodify.core.data.model.MediaItemModel
+import com.andannn.melodify.core.player.util.EXTRA_ALBUM_COVER_ART_KEY
 import com.andannn.melodify.core.player.util.UNIQUE_ID_KEY
 import com.andannn.melodify.core.player.util.buildMediaItem
 
@@ -19,7 +20,9 @@ fun MediaItem.toAppItem(): MediaItemModel = AudioItemModel(
     artistId = "0",
     cdTrackNumber = mediaMetadata.trackNumber ?: 0,
     discNumber = 0,
-    artWorkUri = mediaMetadata.artworkUri.toString(),
+    artWorkUri = mediaMetadata.artworkUri?.toString() ?: mediaMetadata.extras?.getString(
+        EXTRA_ALBUM_COVER_ART_KEY
+    ) ?: "",
     extraUniqueId = mediaMetadata.extras?.getString(UNIQUE_ID_KEY),
     source = Uri.withAppendedPath(
         MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,

--- a/core/player/src/androidMain/kotlin/com/andannn/melodify/core/player/util/MediaItemUtil.kt
+++ b/core/player/src/androidMain/kotlin/com/andannn/melodify/core/player/util/MediaItemUtil.kt
@@ -7,6 +7,7 @@ import androidx.media3.common.MediaItem.RequestMetadata
 import androidx.media3.common.MediaMetadata
 
 const val UNIQUE_ID_KEY = "unique_id"
+const val EXTRA_ALBUM_COVER_ART_KEY = "extra_album_cover_art_key"
 
 fun buildMediaItem(
     title: String,
@@ -43,6 +44,7 @@ fun buildMediaItem(
             .setExtras(
                 Bundle().apply {
                     uniqueId?.let { putString(UNIQUE_ID_KEY, it) }
+                    imageUri?.let { putString(EXTRA_ALBUM_COVER_ART_KEY, it.toString()) }
                 }
             )
             .build()

--- a/core/player/src/androidMain/kotlin/com/andannn/melodify/core/player/util/MediaItemUtil.kt
+++ b/core/player/src/androidMain/kotlin/com/andannn/melodify/core/player/util/MediaItemUtil.kt
@@ -32,7 +32,11 @@ fun buildMediaItem(
             .setGenre(genre)
             .setIsBrowsable(isBrowsable)
             .setIsPlayable(isPlayable)
-            .setArtworkUri(imageUri)
+// ISSUE: https://github.com/andannn/Melodify/issues/243
+// Setting the album URI will cause a system UI issue when playing music.
+// The AndroidX Media3 library automatically handles the notification artwork URI.
+// A crash occurred when querying the album URI from MediaStore. This line is commented out for now.
+//          .setArtworkUri(imageUri)
             .setMediaType(mediaType)
             .setTotalTrackCount(totalTrackCount)
             .setTrackNumber(trackNumber)


### PR DESCRIPTION
FIx #243

The AndroidX Media3 library automatically handles the notification artwork URI. 
A crash occurred when querying the album URI from MediaStore.

1. do not set setArtworkUri in MediaItem
2. Save artwork uri in bundle which used by ui layer
