### PR TITLE
android instrument test

### DIFF
--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -27,6 +27,7 @@ kotlin {
         androidInstrumentedTest.dependencies {
             implementation(libs.androidx.test.runner)
             implementation(libs.androidx.test.core.ktx)
+            implementation(libs.room.runtime)
         }
 
         commonTest.dependencies {

--- a/core/database/connectedAndroidTest.sh
+++ b/core/database/connectedAndroidTest.sh
@@ -1,0 +1,1 @@
+./../../gradlew connectedAndroidTest

--- a/core/database/src/androidInstrumentedTest/kotlin/com/andannn/melodify/core/database/DatabaseTest.android.kt
+++ b/core/database/src/androidInstrumentedTest/kotlin/com/andannn/melodify/core/database/DatabaseTest.android.kt
@@ -4,7 +4,6 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.test.core.app.ApplicationProvider
 
-// ./gradlew core:database:connectedAndroidTest
 
 internal actual fun inMemoryDatabaseBuilder(): RoomDatabase.Builder<MelodifyDataBase> = Room.inMemoryDatabaseBuilder(
     ApplicationProvider.getApplicationContext(),

--- a/core/database/src/androidInstrumentedTest/kotlin/com/andannn/melodify/core/database/MigrationTest.android.kt
+++ b/core/database/src/androidInstrumentedTest/kotlin/com/andannn/melodify/core/database/MigrationTest.android.kt
@@ -1,9 +1,13 @@
 package com.andannn.melodify.core.database
 
 import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.driver.AndroidSQLiteDriver
 import androidx.test.platform.app.InstrumentationRegistry
+import java.io.File
 
 actual fun getMigrationTestHelper(fileName: String) = MigrationTestHelper(
-    InstrumentationRegistry.getInstrumentation(),
-    MelodifyDataBase::class.java,
+    instrumentation = InstrumentationRegistry.getInstrumentation(),
+    databaseClass = MelodifyDataBase::class,
+    file = File(fileName),
+    driver = AndroidSQLiteDriver(),
 )

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,3 +25,6 @@ android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false
 systemProp.https.protocols=TLSv1.2,TLSv1.3
 
+# https://stackoverflow.com/questions/79239698/a-problem-was-found-with-the-configuration-of-task-composeappcopyroomschemast
+org.gradle.unsafe.configuration-cache=true
+


### PR DESCRIPTION
Updates `MigrationTest.android.kt` to use the new `MigrationTestHelper` constructor. Adds the `AndroidSQLiteDriver` as a parameter.
Adds the room dependency to the test implementation. Enables the Gradle configuration cache, resolving a known issue.