### PR TITLE
Clarify playlist integration test action

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,0 +1,14 @@
+# Code review summary
+
+The following review covers the Kotlin multiplatform sources under `shared/`, with emphasis on playlist handling and UI presenters.
+
+## Findings
+
+1. **Title-based grouping crashes on blank names** – `MediaItemModel.keyOf` directly indexes `name[0]` when building a `GroupKey.Title`. Both audio and video fallbacks call `name[0]` without verifying that the string is non-empty, which will throw `StringIndexOutOfBoundsException` whenever the media title is blank (defaults include empty strings). Guard the access with `firstOrNull()`/`takeIf { it.isNotEmpty() }` or drop grouping for blank titles. (`shared/data/src/commonMain/kotlin/com/andannn/melodify/core/data/model/GroupKey.kt`)
+2. **Favorite toggling will crash for videos** – `PlayListRepositoryImpl.toggleFavoriteMedia` accepts a `MediaItemModel` but always casts it to `AudioItemModel` before inserting into the favorites playlist. Any attempt to toggle favorite for a future video entry (there are TODOs to support this) will immediately crash with `ClassCastException`. Either reject non-audio types earlier or add a separate flow for videos before wiring the UI. (`shared/data/src/commonMain/kotlin/com/andannn/melodify/core/data/internal/PlayListRepositoryImpl.kt`)
+3. **Sleep-timer icon ignores repository state** – In `PlayerPresenter`, the timer icon always opens `DialogId.SleepCountingDialog`, even when no timer is running. The dedicated `openSleepTimer` use-case already handles “timer running” vs “pick duration” flows, but this presenter bypasses it, so users never see the option picker from the mini-player. Hook the icon to `openSleepTimer()` (and repository context) for consistent behavior. (`shared/ui/src/commonMain/kotlin/com/andannn/melodify/ui/components/playcontrol/PlayerPresenter.kt`)
+
+## Suggested next steps
+
+* Add unit coverage (or presenter tests) that exercise blank-title grouping and the timer icon logic so regressions are caught earlier.
+* When video favorites become available, add integration tests for the shared playlist repository (`shared/data/.../PlayListRepositoryImpl`) to ensure the cross-media safety checks guard against inserting video entries into the audio-only favorites list.


### PR DESCRIPTION
## Summary
- clarify that the follow-up integration tests belong to `PlayListRepositoryImpl` and must enforce the cross-media favorite safety checks

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d23adff9c833081d8584b715c5f62)