### PR TITLE
build: Upgrade to AGP 9.0 and remove kotlin-android plugin

### DIFF
--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -1,7 +1,6 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.android.application)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.google.service)

--- a/android-benchmark/build.gradle.kts
+++ b/android-benchmark/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.test)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.baselineprofile)
 }
 android {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,6 @@ plugins {
     alias(libs.plugins.jetbrainsCompose) apply false
     alias(libs.plugins.google.service) apply false
     alias(libs.plugins.firebase.crashlytics) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.room) apply false
     alias(libs.plugins.spotless) apply false
     alias(libs.plugins.ktlint) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ androidx-palette = "1.0.0"
 androidxCore = "1.17.0"
 androidxCoreSplashscreen = "1.2.0"
 androidxActivity = "1.12.2"
-androidGradlePlugin = "8.13.2"
+androidGradlePlugin = "9.0.0-rc03"
 kotlinxCoroutines = "1.10.2"
 coil3Compose = "3.3.0"
 androidxRoom = "2.8.4"
@@ -153,7 +153,6 @@ jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "jetbrains-comp
 google-service = { id = "com.google.gms.google-services", version.ref = "googleService" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlytics" }
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 room = { id = "androidx.room", version.ref = "androidxRoom" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,7 @@ dependencyResolutionManagement {
 rootProject.name = "Melodify"
 
 include(":android-app")
-include(":android-benchmark")
+// include(":android-benchmark")
 
 include(":ios-app")
 

--- a/shared/syncer/impl/build.gradle.kts
+++ b/shared/syncer/impl/build.gradle.kts
@@ -13,7 +13,7 @@ kmpExt {
 
 kotlin {
     androidLibrary {
-        namespace = "com.andannn.melodify.core.syncer"
+        namespace = "com.andannn.melodify.core.syncer.impl"
     }
 
     sourceSets {


### PR DESCRIPTION
- Upgrade Android Gradle Plugin to 9.0.0-rc03
- Upgrade Gradle Wrapper to 9.1.0
- Remove the deprecated `kotlin-android` plugin
- Comment out the `:android-benchmark` module
- Fix namespace in `shared/syncer/impl`
Fix https://github.com/andannn/Melodify/issues/504
