### PR TITLE
Added regex to remove extra strings on song tilte and album

### DIFF
--- a/shared/domain/impl/src/commonMain/kotlin/com/andannn/melodify/core/data/internal/LyricRepositoryImpl.kt
+++ b/shared/domain/impl/src/commonMain/kotlin/com/andannn/melodify/core/data/internal/LyricRepositoryImpl.kt
@@ -18,6 +18,15 @@ import kotlinx.coroutines.flow.flow
 
 private const val TAG = "LyricRepository"
 
+private val CLEANUP_PATTERNS = listOf("Remastered", "Deluxe", "Extended", "Album Version")
+
+private val cleanupRegex = Regex(
+    "\\s*\\(${CLEANUP_PATTERNS.joinToString("|") { Regex.escape(it) }}[^)]*\\)",
+    RegexOption.IGNORE_CASE,
+)
+
+internal fun String.cleanTrackMetadata(): String = cleanupRegex.replace(this, "").trim()
+
 internal class LyricRepositoryImpl(
     private val lyricDao: LyricDao,
     private val lyricLocalDataSource: LrclibService,
@@ -40,9 +49,9 @@ internal class LyricRepositoryImpl(
                 emit(LyricRepository.State.Loading)
                 val lyricDataResult =
                     lyricLocalDataSource.getLyric(
-                        trackName = trackName,
+                        trackName = trackName.cleanTrackMetadata(),
                         artistName = artistName,
-                        albumName = albumName,
+                        albumName = albumName?.cleanTrackMetadata(),
                         duration = duration,
                     )
                 val lyricData = lyricDataResult.getOrThrow()


### PR DESCRIPTION
When lrclib is queried, the request doesn't always succeed because the server doesn't recognize songs with extra strings compared to the original title. For example, below is Paranoid (2012 Remaster) with the original code vs. this small regex added before fetching.

## Before
<img width="232" height="448" alt="image" src="https://github.com/user-attachments/assets/a4360c4e-fa99-4823-a451-4f747b5a4cd5" />

## After
<img width="232" height="448" alt="image" src="https://github.com/user-attachments/assets/a5f0b4f9-52d7-4657-bb3f-1374706a6889" />
